### PR TITLE
Output session state selection

### DIFF
--- a/st_widgets/stateful/selectbox.py
+++ b/st_widgets/stateful/selectbox.py
@@ -53,4 +53,4 @@ def stateful_selectbox(
         **kwargs,
     )
 
-    return options[index]  # type: ignore
+    return session[key]


### PR DESCRIPTION
Selectbox now output a session state variable and this correctly prevent clicking it twice in order to change state.